### PR TITLE
Handle installing/removing scripts from custom path

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_size = 2

--- a/.zshrc
+++ b/.zshrc
@@ -34,7 +34,7 @@ if [[ "${terminfo[khome]}" != "" ]]; then
   bindkey "${terminfo[khome]}" beginning-of-line                # [Home] - Go to beginning of line
 fi
 bindkey '^[[8~' end-of-line                                     # End key
-bindkey '^[[F' end-of-line                                     # End key
+bindkey '^[[F' end-of-line                                      # End key
 if [[ "${terminfo[kend]}" != "" ]]; then
   bindkey "${terminfo[kend]}" end-of-line                       # [End] - Go to end of line
 fi
@@ -57,9 +57,9 @@ bindkey '^[[Z' undo                                             # Shift+tab undo
 bindkey -s '^[h' 'htop\n'
 bindkey -s '^[e' 'thunar .\n'
 
-# Theming section  
+# Theming section
 autoload -U compinit colors zcalc
-compinit -d
+compinit
 colors
 
 # edit commands in vim

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -13,9 +13,11 @@ alias cp="cp -i"                                                # Confirm before
 alias df='df -h'                                                # Human-readable sizes
 alias free='free -m'                                            # Show sizes in MB
 alias gitu='git add . && git commit && git push'
+
+alias code="codium"
 alias du_sort="du -h --max-depth=1 | sort -h"
 
 [ "$SHELL" = "/bin/zsh" ] || [ "$SHELL" = "/usr/bin/zsh" ] && \
   source "${__MY_TOOLS_PATH}/.zshrc" && \
-  for f in $(find "${__MY_TOOLS_PATH}/shared" "${__MY_TOOLS_PATH}/plugins" -type f); do; source $f; done
+  for f in $(find "${__MY_TOOLS_PATH}/shared" "${__MY_TOOLS_PATH}/plugins" -type f); do source $f; done
 

--- a/shared/installer.sh
+++ b/shared/installer.sh
@@ -2,20 +2,51 @@
 
 # Methods to handle installing/removing scripts from custom path dir 'scripts'
 
-install_script() {
-  [ "$#" -ne 1 ] && echo "Expected arg: script name" && return 1
-  cp "$1" "$__MY_TOOLS_PATH/scripts"
-  chmod 700 "$__MY_TOOLS_PATH/scripts/$1"
+__install_to() {
+  local -r program="$1"
+  local -r target="$2"
+  echo "program: $1"
+  echo "target: $2"
+  cp "$program" "$2"
+  chmod u+x "$2/$program"
 }
 
-uninstall_scripts() {
-  [ "$#" -ne 1 ] && echo "Expected arg: script name" && return 1
+install_script() {
+  [ "$#" -ne 1 ] && echo "Expected 1 arg: script file" && return 1
+  __install_to "$1" "$__MY_TOOLS_PATH/scripts/"
+}
+
+uninstall_script() {
+  [ "$#" -ne 1 ] && echo "Expected 1 arg: script file" && return 1
   rm "$__MY_TOOLS_PATH/scripts/$1"
 }
 
+install_to_path() {
+  [ "$#" -ne 1 ] && echo "Expected 1 arg: binary file" && return 1
+  __install_to "$1" "$HOME/.local/bin/"
+}
+
+uninstall_from_path() {
+  [ "$#" -ne 1 ] && echo "Expected 1 arg: binary file" && return 1
+  rm "$HOME/.local/bin/$1"
+}
+
+__uninstall_completion() {
+  local files
+  if [ "$#" -eq 2 ]; then
+    files="$(find "$1" -name "$2" -exec basename {} \;)"
+  else
+    files="$(find "$1" -exec basename {} \;)"
+  fi
+  COMPREPLY=($(compgen -W "$files" -- "${COMP_WORDS[1]}"))
+}
+
 _uninstall_scripts_completion() {
-  echo "$(find "$__MY_TOOLS_PATH/scripts/" -name '*.sh' -exec basename {} \;)"
-  COMPREPLY=($(compgen -W "$scs" -- "${COMP_WORDS[1]}"))
+  __uninstall_completion "$__MY_TOOLS_PATH/scripts/" "*.sh"
+}
+
+_uninstall_from_path_completion() {
+  __uninstall_completion "$HOME/.local/bin/"
 }
 
 if ! typeset -f foo > /dev/null; then
@@ -40,4 +71,5 @@ if ! typeset -f foo > /dev/null; then
   }
 fi
 
-complete -F _uninstall_scripts_completion uninstall_scripts
+complete -F _uninstall_scripts_completion uninstall_script
+complete -F _uninstall_from_path_completion uninstall_from_path

--- a/shared/installer.sh
+++ b/shared/installer.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Methods to handle installing/removing scripts from custom path dir 'scripts'
+
+install_script() {
+  [ "$#" -ne 1 ] && echo "Expected arg: script name" && return 1
+  cp "$1" "$__MY_TOOLS_PATH/scripts"
+  chmod 700 "$__MY_TOOLS_PATH/scripts/$1"
+}
+
+uninstall_scripts() {
+  [ "$#" -ne 1 ] && echo "Expected arg: script name" && return 1
+  rm "$__MY_TOOLS_PATH/scripts/$1"
+}
+
+_uninstall_scripts_completion() {
+  echo "$(find "$__MY_TOOLS_PATH/scripts/" -name '*.sh' -exec basename {} \;)"
+  COMPREPLY=($(compgen -W "$scs" -- "${COMP_WORDS[1]}"))
+}
+
+if ! typeset -f foo > /dev/null; then
+  # Fix: for reasons compinit methods are not available at this point, so we copy 'complete' defintion
+  complete () {
+    emulate -L zsh
+    local args void cmd print remove
+    args=("$@")
+    zparseopts -D -a void o: A: G: W: C: F: P: S: X: a b c d e f g j k u v p=print r=remove
+    if [[ -n $print ]]
+    then
+      printf 'complete %2$s %1$s\n' "${(@kv)_comps[(R)_bash*]#* }"
+    elif [[ -n $remove ]]
+    then
+      for cmd
+      do
+        unset "_comps[$cmd]"
+      done
+    else
+      compdef _bash_complete\ ${(j. .)${(q)args[1,-1-$#]}} "$@"
+    fi
+  }
+fi
+
+complete -F _uninstall_scripts_completion uninstall_scripts


### PR DESCRIPTION
* Add functions: `install_script` & `uninstall_scripts`: allow easy add and remove scripts from `$TOOLS/scripts` which are added to path. For scripts or other binaries that don't need to be git managed, `install_to_path` & `uninstall_from_path` have been added with similar behavior but copying to `~/.local/bin`.
* Add autocompletion to `uninstall_scripts`, there seems to be an issue with `compinit` methods not being available even after the initialization (seen also in MacOS, but in mac, delaying sourcing my script works). I resorted to hack fix of checking if complete functions is available and re-setting it manually.
* Add .editorconfig
* Minor formatting fixes
