### PR TITLE
Force TearFree option in main monitor

### DIFF
--- a/scripts/xrandr_setup.sh
+++ b/scripts/xrandr_setup.sh
@@ -2,7 +2,7 @@
 
 setup() {
   [ "$#" -eq 0 ] && freq="120" || freq="$1"
-  xrandr --output DisplayPort-0 --mode 2560x1440 --rate "$freq"
+  xrandr --output DisplayPort-0 --mode 2560x1440 --rate "$freq" --set TearFree on
   xrandr --output HDMI-A-0 --mode 2560x1440 --rate 60 --set TearFree on
   xrandr --output HDMI-A-0 --right-of DisplayPort-0
 }


### PR DESCRIPTION
Older games that don't support VRR and have no fps limit options, can still experience tearing when forcing limits for example with DXVK_FRAME_RATE.
Applied for Stalker:SoC.