### PR TITLE
Add 'gh_install_latest_release' method

### DIFF
--- a/modules/docker_k8s.sh
+++ b/modules/docker_k8s.sh
@@ -18,7 +18,7 @@ then
 
   k_port_forward() {
     local pod_name=$(kubectl get pods --no-headers | grep $1 | awk '{print $1}')
-    local pods_count=$(echo $pod_name | wc -l)
+    local pods_count=$(echo "$pod_name" | wc -l)
     local port=8080
     if [ "$#" -eq 2 ]; then
       port="$2"

--- a/shared/gh.sh
+++ b/shared/gh.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+# ignore validation files like shas
+
+# Supports 4 arguments
+#  1: gh repo owner
+#  2: gh repo name
+#  3: asset name as described in the gh release, if not set, will print available found
+#  4: (optional) final name for installation
+gh_install_latest_release() {
+  local -r os="linux" arch="amd64"
+  local -r owner=${1:?"repo owner must be set"}
+  local -r repo=${2:?"repo name must be set"}
+
+  local -r assets=$(curl -sL \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "https://api.github.com/repos/$owner/$repo/releases/latest")
+
+  if [ "$#" -le 2 ]; then
+    echo "Release TAG: $(echo -E "$assets" | jq -r '.tag_name')"
+    echo "Files found:"
+    echo -E "$assets" | jq -r '.assets[] | "\(.name)  \(.browser_download_url)"' | grep -v "sha" | grep "$os"
+  else
+    local -r asset_name=${3:?"asset name must be set"}
+    local -r download_url=$(echo -E "$assets" | jq -r ".assets[] | select(.name == \"$asset_name\") | .browser_download_url")
+    local -r temp_dir=$(mktemp -d)
+    curl -sL "$download_url" -O --output-dir "$temp_dir"
+    if [ "$#" -eq 4 ]; then
+      install_to_path "$temp_dir/$asset_name" "$4"
+    else
+      install_to_path "$temp_dir/$asset_name"
+    fi
+  fi
+}

--- a/shared/installer.sh
+++ b/shared/installer.sh
@@ -3,10 +3,15 @@
 # Methods to handle installing/removing scripts from custom path dir 'scripts'
 
 __install_to() {
-  local -r program="$1"
-  local -r target="$2"
+  local -r program="${1##*/}"
+  local -r target_dir="$2"
   cp "$program" "$2"
-  chmod u+x "$2/$program"
+  if [ "$#" -eq 3 ]; then
+    mv "$target_dir/$program" "$target_dir/$3"
+    chmod u+x "$target_dir/$3"
+  else
+    chmod u+x "$target_dir/$program"
+  fi
 }
 
 install_script() {
@@ -19,9 +24,17 @@ uninstall_script() {
   rm "$__MY_TOOLS_PATH/scripts/$1"
 }
 
+# Copies a binary into a PATH available location
+#  1: path of the binary
+#  2: (optional) final name for the binary
 install_to_path() {
-  [ "$#" -ne 1 ] && echo "Expected 1 arg: binary file" && return 1
-  __install_to "$1" "$HOME/.local/bin/"
+  [ "$#" -gt 2 ] && echo "Expected 1 or 2 args: binary_file [final_name]" && return 1
+
+  if [ "$#" -eq 1 ]; then
+    __install_to "$1" "$HOME/.local/bin/"
+  else
+    __install_to "$1" "$HOME/.local/bin/" "$2"
+  fi
 }
 
 uninstall_from_path() {


### PR DESCRIPTION
Method supports passing gh repo to find latest release, download and copy to PATH.
Currently limitations:
* Releases are not compressed
* No autocompletion or usability features
* Additional fix to 'install_to_path' when passing absolutes paths