### PR TITLE
Add missing bspc_resize_window.sh

### DIFF
--- a/scripts/bspc_resize_window.sh
+++ b/scripts/bspc_resize_window.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+STEP=60
+
+case $1 in
+    east)  dir=right; falldir=left;   sign=+;;
+    west)  dir=right; falldir=left;   sign=-;;
+    north) dir=top;   falldir=bottom; sign=-;;
+    south) dir=top;   falldir=bottom; sign=+
+esac
+
+case $dir in
+    right) x=$sign$STEP; y=0;;
+    top)   y=$sign$STEP; x=0
+esac
+
+bspc node -z "$dir" "$x" "$y" || bspc node -z "$falldir" "$x" "$y"


### PR DESCRIPTION
The shortcut to resize windows was not working and it was due to a script missing.
Restored from the comment in `sxhkdrc`  comment.